### PR TITLE
Cryptosuite factory, bbs legacy, bbs, eddsa (#2426)  * `did:web`

### DIFF
--- a/proto/services/verifiable-credentials/templates/v1/templates.proto
+++ b/proto/services/verifiable-credentials/templates/v1/templates.proto
@@ -417,5 +417,7 @@ enum VerificationShareType {
 // A patch to apply to an existing template field
 message VerificationTemplateFieldPatch {
   // Human-readable name of the field
-  optional string usage_policy = 1;
+  VerificationShareType field_share_type = 1;
+  // User-facing explanation of what is done with this data
+  string usage_policy = 2;
 }

--- a/proto/services/verifiable-credentials/v1/verifiable-credentials.proto
+++ b/proto/services/verifiable-credentials/v1/verifiable-credentials.proto
@@ -13,20 +13,20 @@ import "services/options/field-options.proto";
 message IssueFromTemplateRequest {
   reserved 3;
   reserved "framework_id";
-  
+
   // ID of template to use
   string template_id = 1;
 
   // JSON document string with keys corresponding to the fields of
   // the template referenced by `template_id`
   string values_json = 2;
-  
+
 
   // Save a copy of the issued credential to this user's wallet. This copy will only contain
   // the credential data, but not the secret proof value. Issuers may use this data to
   // keep track of the details for revocation status.
   bool save_copy = 4;
-  
+
   // The ISO8601 expiration UTC date of the credential. This is a reserved field in the VC specification.
   // If specified, the issued credential will contain an expiration date.
   // https://www.w3.org/TR/vc-data-model/#expiration
@@ -35,6 +35,20 @@ message IssueFromTemplateRequest {
   // If true, the issued credential will contain an attestation of the issuer's membership in the ecosystem's
   // governance framework.
   bool include_governance = 6;
+
+  // The type of signature to use when signing the credential. Defaults to `EXPERIMENTAL`.
+  SignatureType signature_type = 7;
+}
+
+enum SignatureType {
+  // The signature type is not specified. The experimental signature type will be used.
+  UNSPECIFIED = 0;
+  // The signature type uses EdDSA with the Ed25519 curve (NIST compliant).
+  // This type of signature does not support selective disclosure of attributes.
+  STANDARD = 1;
+  // The signature type uses BBS signatures with BLS12-381 curve (experimental).
+  // This type of signature allows for selective disclosure of attributes.
+  EXPERIMENTAL = 2;
 }
 
 // Response to `IssueFromTemplateRequest`
@@ -213,7 +227,7 @@ message CreateCredentialOfferRequest{
   // JSON document string with keys corresponding to the fields of
   // the template referenced by `template_id`
   string values_json = 2;
-  // If true, the credential will be issued with holder binding by specifying 
+  // If true, the credential will be issued with holder binding by specifying
   // the holder DID in the credential subject
   bool holder_binding = 3;
   // If true, the issued credential will contain an attestation of the issuer's membership in the ecosystem's
@@ -222,12 +236,14 @@ message CreateCredentialOfferRequest{
   // If true, a short URL link will be generated that can be used to share the credential offer with the holder.
   // This link will point to the credential offer in the wallet app.
   bool generate_share_url = 5;
+  // The type of signature to use when signing the credential. Defaults to `EXPERIMENTAL`.
+  SignatureType signature_type = 7;
 }
 message CreateCredentialOfferResponse{
   // The JSON document that contains the credential offer
   string document_json = 1;
   // If requested, a URL that can be used to share the credential offer with the holder.
-  // This is a short URL that can be used in a QR code and will redirect the 
+  // This is a short URL that can be used in a QR code and will redirect the
   // holder to the credential offer using the wallet app.
   string share_url = 2;
 }
@@ -243,7 +259,7 @@ message AcceptCredentialRequest{
 message AcceptCredentialResponse{
   // The ID of the item in the wallet that contains the issued credential
   string item_id = 1;
-  // The JSON document that contains the issued credential. 
+  // The JSON document that contains the issued credential.
   // This item is already stored in the wallet.
   string document_json = 2;
 }


### PR DESCRIPTION
Cryptosuite factory, bbs legacy, bbs, eddsa (#2426)  * `did:web` endpoints rename, and expand `resolvedidweb()` * Exposes `MigrateToDidWeb` to SDK (was previously only internal) * Properly marks did-upgrades as `skip` to save money  * fix: Validate these are our keys  * fix: Do the actual did upgrade!  * no message  * spike: new endpoints for did's  * fix: Address @geel9 feedback * did record list * Providing target host domain for `did:web` template generation  * no message  * fix: Address more feedback * remove public service endpoints * `Verify` vs `Validate`  * no message  * spike: Here we go!  * no message  * no message  * fix: Json subset compare  * fix: `tid` domain separator  * no message  * refactor: Move `DidWebController` to OIDC for `.connect` subdomain routing  * no message  * `dotnet format`  * fix: Use proper key signatures  * fix: don't remove http1  * fix: Provide the `controller` object  * feat: Show your did:web document!  * fix: bad merge  * cryptosuite factory, bbs legacy, bbs, eddsa  * Enable tests  * Legacy bbs sign works  * Introduce did:noop  * Fix tests  * verify tests pass  * Fix all tests  * Add vc eddsa test  * Comment, and did:web url fix  * Use eddsa for authentication  * Fix test  * Fix jsonld test  * Actually fix the test  * Cleanup  * Fix CI  * Migrate did:key accounts to did:web  * Add migration path for did:ion  * Move JSON extensions into separate file  * Clean warnings  * Fix trust registry  * Merge fix  * Fix trust registry test  * Format  * Format  * Correct use of did web  ---------  Co-authored-by: Scott Phillips <polygonguru@gmail.com>

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new field `field_share_type` and a new enum `SignatureType` to the verifiable-credentials templates and verifiable-credentials services. 

### Detailed summary
- Added `field_share_type` field to `VerificationTemplateFieldPatch` message in `templates.proto`
- Added `usage_policy` field to `VerificationTemplateFieldPatch` message in `templates.proto`
- Added `signature_type` field to `IssueFromTemplateRequest` message in `verifiable-credentials.proto`
- Added `signature_type` field to `CreateCredentialOfferRequest` message in `verifiable-credentials.proto`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->