### PR TITLE
Build/remove dashboard/oidc4vp sdk dependency (#2460)  * spike:

### DIFF
--- a/proto/services/account/v1/account.proto
+++ b/proto/services/account/v1/account.proto
@@ -8,44 +8,15 @@ option java_multiple_files = true;
 
 import "services/options/field-options.proto";
 
-// Request for creating or signing into an account
-message SignInRequest {
-  // Account registration details
-  AccountDetails details = 1 [(options.optional) = true];
-
-  // ID of Ecosystem to use
-  // Ignored if `invitation_code` is passed
-  string ecosystem_id = 3 [(options.optional) = true];
-
-  reserved 2;
-  reserved "invitation_code";
-}
-
 // Account registration details
 message AccountDetails
 {
   // Account name
   string name = 1 [(options.optional) = true];
-  // Email address of account. 
+  // Email address of account.
   string email = 2 [(options.optional) = true, deprecated = true];
   // SMS number including country code
   string sms = 3 [(options.optional) = true, deprecated = true];
-}
-
-// Response for creating new account
-// This object will indicate if a confirmation code
-// was sent to one of the users two-factor methods
-// like email, SMS, etc.
-message SignInResponse {
-  // Indicates if confirmation of account is required.
-  ConfirmationMethod confirmation_method = 3;
-
-  // Contains authentication data for use with the current device.
-  // This object must be stored in a secure place. It can also be
-  // protected with a PIN, but this is optional.
-  // See the docs at https://docs.trinsic.id for more information
-  // on working with authentication data.
-  AccountProfile profile = 4;
 }
 
 // Confirmation method type for two-factor workflows
@@ -62,6 +33,15 @@ enum ConfirmationMethod {
   Other = 10;
 }
 
+// Token protection info
+message TokenProtection {
+  // Indicates if token is protected using a PIN,
+  // security code, HSM secret, etc.
+  bool enabled = 1;
+  // The method used to protect the token
+  ConfirmationMethod method = 2;
+}
+
 // Device profile containing sensitive authentication data.
 // This information should be stored securely
 message AccountProfile {
@@ -76,15 +56,6 @@ message AccountProfile {
   // If token protection is enabled, implementations must supply
   // protection secret before using the token for authentication.
   TokenProtection protection = 4;
-}
-
-// Token protection info
-message TokenProtection {
-  // Indicates if token is protected using a PIN,
-  // security code, HSM secret, etc.
-  bool enabled = 1;
-  // The method used to protect the token
-  ConfirmationMethod method = 2;
 }
 
 // Request for information about the account used to make the request
@@ -168,13 +139,6 @@ message WalletAuthToken {
 }
 
 service Account {
-  // Sign in to an already existing account
-  rpc SignIn              (SignInRequest)             returns (SignInResponse) {
-    option deprecated = true;
-    option (options.sdk_template_option).ignore = true;
-    option (options.sdk_template_option).anonymous = true;
-  }
-
   // Begin login flow for specified account, creating one if it does not already exist
   rpc Login               (LoginRequest)              returns (LoginResponse) {
     option deprecated = true;

--- a/proto/services/common/v1/common.proto
+++ b/proto/services/common/v1/common.proto
@@ -31,3 +31,14 @@ message Nonce {
   int64 timestamp = 1; // UTC unix millisecond timestamp the request was made
   bytes request_hash = 2; // blake3256 hash of the request body
 }
+
+message TrinsicClientOptions {
+  // Trinsic API endpoint. Defaults to `prod.trinsic.cloud`
+  string server_endpoint = 1;
+  // Trinsic API port; defaults to `443`
+  int32 server_port = 2;
+  // Whether TLS is enabled between SDK and Trinsic API; defaults to `true`
+  bool server_use_tls = 3;
+  // Authentication token for SDK calls; defaults to empty string (unauthenticated)
+  string auth_token = 4;
+}

--- a/proto/services/verifiable-credentials/templates/v1/templates.proto
+++ b/proto/services/verifiable-credentials/templates/v1/templates.proto
@@ -417,5 +417,7 @@ enum VerificationShareType {
 // A patch to apply to an existing template field
 message VerificationTemplateFieldPatch {
   // Human-readable name of the field
-  optional string usage_policy = 1;
+  VerificationShareType field_share_type = 1;
+  // User-facing explanation of what is done with this data
+  string usage_policy = 2;
 }

--- a/proto/services/verifiable-credentials/v1/verifiable-credentials.proto
+++ b/proto/services/verifiable-credentials/v1/verifiable-credentials.proto
@@ -13,20 +13,20 @@ import "services/options/field-options.proto";
 message IssueFromTemplateRequest {
   reserved 3;
   reserved "framework_id";
-  
+
   // ID of template to use
   string template_id = 1;
 
   // JSON document string with keys corresponding to the fields of
   // the template referenced by `template_id`
   string values_json = 2;
-  
+
 
   // Save a copy of the issued credential to this user's wallet. This copy will only contain
   // the credential data, but not the secret proof value. Issuers may use this data to
   // keep track of the details for revocation status.
   bool save_copy = 4;
-  
+
   // The ISO8601 expiration UTC date of the credential. This is a reserved field in the VC specification.
   // If specified, the issued credential will contain an expiration date.
   // https://www.w3.org/TR/vc-data-model/#expiration
@@ -35,6 +35,20 @@ message IssueFromTemplateRequest {
   // If true, the issued credential will contain an attestation of the issuer's membership in the ecosystem's
   // governance framework.
   bool include_governance = 6;
+
+  // The type of signature to use when signing the credential. Defaults to `EXPERIMENTAL`.
+  SignatureType signature_type = 7;
+}
+
+enum SignatureType {
+  // The signature type is not specified. The experimental signature type will be used.
+  UNSPECIFIED = 0;
+  // The signature type uses EdDSA with the Ed25519 curve (NIST compliant).
+  // This type of signature does not support selective disclosure of attributes.
+  STANDARD = 1;
+  // The signature type uses BBS signatures with BLS12-381 curve (experimental).
+  // This type of signature allows for selective disclosure of attributes.
+  EXPERIMENTAL = 2;
 }
 
 // Response to `IssueFromTemplateRequest`
@@ -213,7 +227,7 @@ message CreateCredentialOfferRequest{
   // JSON document string with keys corresponding to the fields of
   // the template referenced by `template_id`
   string values_json = 2;
-  // If true, the credential will be issued with holder binding by specifying 
+  // If true, the credential will be issued with holder binding by specifying
   // the holder DID in the credential subject
   bool holder_binding = 3;
   // If true, the issued credential will contain an attestation of the issuer's membership in the ecosystem's
@@ -222,12 +236,14 @@ message CreateCredentialOfferRequest{
   // If true, a short URL link will be generated that can be used to share the credential offer with the holder.
   // This link will point to the credential offer in the wallet app.
   bool generate_share_url = 5;
+  // The type of signature to use when signing the credential. Defaults to `EXPERIMENTAL`.
+  SignatureType signature_type = 7;
 }
 message CreateCredentialOfferResponse{
   // The JSON document that contains the credential offer
   string document_json = 1;
   // If requested, a URL that can be used to share the credential offer with the holder.
-  // This is a short URL that can be used in a QR code and will redirect the 
+  // This is a short URL that can be used in a QR code and will redirect the
   // holder to the credential offer using the wallet app.
   string share_url = 2;
 }
@@ -243,7 +259,7 @@ message AcceptCredentialRequest{
 message AcceptCredentialResponse{
   // The ID of the item in the wallet that contains the issued credential
   string item_id = 1;
-  // The JSON document that contains the issued credential. 
+  // The JSON document that contains the issued credential.
   // This item is already stored in the wallet.
   string document_json = 2;
 }


### PR DESCRIPTION
Build/remove dashboard/oidc4vp sdk dependency (#2460)  * spike: Switch away from published SDK  * fix: Bear that token!  * Make the options correct.  * `dotnet format`  * feat: remove `trinsic-sdk` from `oidc4vp`  * fix: Make tests work.  * no message  * Update dashboard/service/Dashboard/Services/TeamService.cs  Co-authored-by: Tomislav Markovski <tmarkovski@gmail.com>  * Update proto/services/common/v1/common.proto  Co-authored-by: Tomislav Markovski <tmarkovski@gmail.com>  * fix: Add support for cached channels  * no message  * no message  * no message  * fix: in-cluster routing  * fix: `dotnet format` `CloneWithAuthToken` `MemoryCache`  * fix: Cache channels by endpoint, not authtoken  * fix: Pass metadata along with every call.  ---------  Co-authored-by: Tomislav Markovski <tmarkovski@gmail.com>

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new field `VerificationShareType` and `usage_policy` in the `VerificationTemplateFieldPatch` message in `templates.proto`.
- Added a new message `TrinsicClientOptions` in `common.proto` to specify Trinsic API endpoint, port, TLS, and authentication token.
- Removed the `SignInRequest` and `SignInResponse` messages from `account.proto`.
- Added new fields `TokenProtection` and `SignatureType` in the `AccountProfile` message in `account.proto`.
- Added new fields `signature_type` in the `IssueFromTemplateRequest` and `CreateCredentialOfferRequest` messages in `verifiable-credentials.proto`.
- Added new message `CreateCredentialOfferResponse` in `verifiable-credentials.proto`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->